### PR TITLE
Community organizing/open source way books

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ This is a list of books (in no particular order) we keep in our library(s) which
 | The Death and Life of Great American Cities | by Jane Jacobs                           |
 | How Buildings Learn: What Happens After They're Built | by Stewart Brand                         |
 | A Pattern Language: Towns, Buildings, Construction (Center for Environmental Structure) | by Christopher Alexander                 |
+| Cultivating Communities of Practice      | by Etienne Wenger, Richard A. McDermott, William M. Snyder      |
+| Digital Habitats: stewarding technology for communities      | by Etienne Wenger, Nancy White, and John D. Smith     |
+| Producing Open Source Software (2nd Edition)     |  by Karl Fogel     |
+| The Starfish and the Spider     |    by Ori Brafman and Rod A. Beckstrom     |
+| Wikinomics       |  by Don Tapscott and Anthony D. Williams     |
+| Open Advice - FOSS: What We Wish We Had Known When We Started   |  Edited by Lydia Pintscher & 43+ authors    |
 
 
 ## Books authored by Red Hat staff:
@@ -137,3 +143,4 @@ This list is inspired by these sources and others:
 - https://devops.com/five-great-books-on-devops/
 - https://blog.versionone.com/the-7-best-devops-books/
 - https://www.quora.com/What-are-the-best-books-on-devops
+- http://www.theopensourceway.org/wiki/Data_and_references


### PR DESCRIPTION
These are all on a list at http://www.theopensourceway.org/wiki/Data_and_references and I added that link to the "inspired by these sources" section.

I hesitated to suggest The Open Source Way itself as it is an ongoing, always-a-work-in-progress, and undergoing active editing to improve. It may not be a good resource for the target audience of this list. If you take a look and want to include it, you can use this change under the Red Hat authors section

|  The Open Source Way(http://www.theopensourceway.org) | Karsten Wade and others |

... or you can let me know to add it myself and I'll make the pull request.